### PR TITLE
chore: replace fast-json-stable-stringify with safe-stable-stringify

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2264,7 +2264,8 @@
     "fast-json-stable-stringify": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
+      "dev": true
     },
     "fast-levenshtein": {
       "version": "2.0.6",
@@ -2402,7 +2403,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2423,12 +2425,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2443,17 +2447,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2570,7 +2577,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2582,6 +2590,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2596,6 +2605,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2603,12 +2613,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -2627,6 +2639,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2707,7 +2720,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2719,6 +2733,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2804,7 +2819,8 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2840,6 +2856,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2859,6 +2876,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2902,12 +2920,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -6303,6 +6323,11 @@
       "requires": {
         "ret": "~0.1.10"
       }
+    },
+    "safe-stable-stringify": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-1.1.1.tgz",
+      "integrity": "sha512-ERq4hUjKDbJfE4+XtZLFPCDi8Vb1JqaxAPTxWFLBx8XcAlf9Bda/ZJdVezs/NAfsMQScyIlUMx+Yeu7P7rx5jw=="
     },
     "safer-buffer": {
       "version": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "typescript": "3.x"
   },
   "dependencies": {
-    "fast-json-stable-stringify": "2.x"
+    "safe-stable-stringify": "2.x"
   },
   "lint-staged": {
     "linters": {

--- a/src/logger/message.ts
+++ b/src/logger/message.ts
@@ -1,4 +1,4 @@
-import jsonStringify from 'fast-json-stable-stringify'
+import jsonStringify from 'safe-stable-stringify'
 
 import { LogContext, LogContexts } from './context'
 import { logLevelNameFor } from './level'
@@ -33,7 +33,7 @@ const registerLogFormatter = (name: string, format: LogMessageFormatter) => {
 
 function defaultLogFormatters() {
   return {
-    json: (msg: LogMessage) => jsonStringify({ ...msg, time: new Date(msg.time) }, { cycles: true }),
+    json: (msg: LogMessage) => jsonStringify({ ...msg, time: new Date(msg.time) }),
     simple: (msg: LogMessage) =>
       `${msg.context[LogContexts.package] || msg.context[LogContexts.application] || 'main'}[${msg.context[
         LogContexts.namespace

--- a/src/shims.d.ts
+++ b/src/shims.d.ts
@@ -1,7 +1,0 @@
-declare module 'fast-json-stable-stringify' {
-  const fastJsonStableStringify: (input: any, opt?: {
-    cmp?: (a: {key: PropertyKey, value: any}, b: {key: PropertyKey, value: any}) => number,
-    cycles?: boolean,
-  }) => string
-  export = fastJsonStableStringify
-}


### PR DESCRIPTION
This is a performance improvement as the latter is actually faster.
The circular reference detection is a breaking change due to now
producing valid JSON. The former implementation caused the output to
be invalid JSON in such cases.

fast-json-stable-stringify x 18,765 ops/sec ±0.71% (94 runs sampled)
safe-stable-stringify x 30,367 ops/sec ±0.39% (96 runs sampled)

BigInt are from now on also stringified.